### PR TITLE
Use wl-copy to copy snippet to clipboard in `wl` mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 from ulauncher.api.shared.action.ActionList import ActionList
 
-from src.functions import get_snippets, copy_to_clipboard_xsel
+from src.functions import get_snippets, copy_to_clipboard_xsel, copy_to_clipboard_wl
 from src.items import no_input_item, show_suggestion_items, show_var_input
 
 
@@ -55,6 +55,9 @@ class ItemEnterEventLister(EventListener):
 
         if copy_mode == "xsel":
             copy_to_clipboard_xsel(snippet)
+            return HideWindowAction()
+        elif copy_mode == "wl":
+            copy_to_clipboard_wl(snippet)
             return HideWindowAction()
         else:
             return CopyToClipboardAction(snippet)


### PR DESCRIPTION
3c1ad70ec4b4865d2aafceb5847d783544d9c7ff introduced support for wl-clipboard for better clipboard support on Wayland.

This implementation used `wl-paste` to **get** data from the clipboard, but did use `wl-paste` to put data onto the clipboard, despite a function for it being defined.

This commit changes the behavior to also use `wl-paste` to **put** data on the clipboard.

This makes the implementation similar to xsel, which uses xsel for both copy and paste when mode is set to xsel (instead of Gtk).