### PR TITLE
Fix silent/infinite hanging when no globals exist

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -106,11 +106,11 @@ class Snippet:
         if os.path.exists(self.globals_path):
             globals = import_file("globals", self.globals_path).globals
 
-            clipboard_func = output_from_clipboard_gtk
-            if copy_mode == "xsel":
-                clipboard_func = output_from_clipboard_xsel
-            elif copy_mode == "wl":
-                clipboard_func = output_from_clipboard_wl
+        clipboard_func = output_from_clipboard_gtk
+        if copy_mode == "xsel":
+            clipboard_func = output_from_clipboard_xsel
+        elif copy_mode == "wl":
+            clipboard_func = output_from_clipboard_wl
 
         return template.render(
             date=date,


### PR DESCRIPTION
The clipboard_func variable is defined within the conditional of `if os.path.exists(self.globals_path):` in `src/functions.py`.

When `self.globals_path` does not exist, this causes a `UnboundLocalError` exception to be thrown:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/main.py", line 54, in on_event
    snippet = extension.snippet.render(copy_mode=copy_mode)
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/src/functions.py", line 117, in render
    clipboard=clipboard_func,
UnboundLocalError: local variable 'clipboard_func' referenced before assignment
```

This will crash the plugin and leave the user with no feedback.

It is fixed by unconditionally defining `clipboard_func`.