### PR TITLE
Reset plugin state on crash in extension.snippet.render()

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,12 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 from ulauncher.api.shared.event import KeywordQueryEvent
 from ulauncher.api.shared.event import ItemEnterEvent
 from ulauncher.api.shared.event import SystemExitEvent
+from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 from ulauncher.api.shared.action.ActionList import ActionList
+from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
 
 from src.functions import get_snippets, copy_to_clipboard_xsel
 from src.items import no_input_item, show_suggestion_items, show_var_input
@@ -50,8 +52,14 @@ class ItemEnterEventLister(EventListener):
             )])
 
         copy_mode = extension.preferences["snippets_copy_mode"]
-        snippet = extension.snippet.render(copy_mode=copy_mode)
-        extension.reset()
+        try:
+            snippet = extension.snippet.render(copy_mode=copy_mode)
+        except Exception as e:
+            return RenderResultListAction([
+                ExtensionResultItem(name=str(e), on_enter=DoNothingAction())
+            ])
+        finally:
+            extension.reset()
 
         if copy_mode == "xsel":
             copy_to_clipboard_xsel(snippet)


### PR DESCRIPTION
Prior to this change, an exception in render would make the plugin hang on "Loading" when an exception like the following happens:

```
ulauncher-snippets | 2021-05-07 14:52:08,908 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event ItemEnterEvent
Traceback (most recent call last):
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/main.py", line 57, in on_event
    snippet = extension.snippet.render(copy_mode=copy_mode)
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/src/functions.py", line 103, in render
    template = Template(snippet.content)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1031, in __new__
    return env.from_string(source, template_class=cls)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 941, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 638, in compile
    self.handle_exception(source=source_hint)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/lib/python3.9/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<unknown>", line 1, in template
jinja2.exceptions.TemplateAssertionError: no filter named 'replace_with_symbol'
```

After closing the ulauncher window and then attempting to insert a new
snippet, it would hang without feedback because of corruption of its
internal state:

```
ulauncher-snippets | 2021-05-07 14:52:15,427 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/main.py", line 82, in on_event
    show_var_input(extension.snippet, extension.variable, search)
AttributeError: 'SnippetsExtension' object has no attribute 'variable'
```

With this change, this code path is wrapped in try/except which will (1) display the exception message to the end-user and (2) consistently reset plugin state afterwards.