### PR TITLE
Add support for desktop notifications and Markdown/HTML snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ vars:
         default: "NewComponent"
     other_var:
         label: "A var with no default"
+markdown: false
+markdown_extensions: []
 ---
 
 My snippet {{ date('now') }}!
@@ -63,8 +65,22 @@ Each key of the frontmatter does have a fallback:
 * `description`: First 40 characters of your snippet
 * `icon`: The snippets extensions icon
 * `vars`: An empty dictionary
+* `markdown`: Indicates this snippet should render markdown. Disabled by default.
+* `markdown_extensions`: Sets the [Markdown extensions] to use when `markdown` is enabled.
 
 If you define vars for your snippet the user will get inputs for each one and you can you them in your snippet. See below Placeholder -> Variables. To use the default value you need to input `-`.
+
+### Markdown snippets
+
+> **Note:** Markdown snippets only work in `xsel` and `wl` modes.
+
+Normally, snippets are rendered as plain text.
+
+When `markdown: true` is specified, you can write snippets in markdown which will be rendered to HTML (using [Python-Markdown]) before being put on the clipboard.
+This allows rich text snippets in applications that understand HTML clipboard content.
+
+By default, all of the [extra][markdown-extra] extensions as well as the [sane lists][markdown-sane-lists] extension are enabled.
+It's possible to override this by specifying a list of extensions in `markdown_extensions` yourself.
 
 ### Placeholder
 
@@ -200,3 +216,8 @@ Currently, doctest is used for the `functions` module. To run the tests execute 
 ```
 python3 src/functions.py
 ``` 
+
+[Python-Markdown]: https://python-markdown.github.io/
+[Markdown extensions]: https://python-markdown.github.io/extensions/
+[Markdown-extra]: https://python-markdown.github.io/extensions/extra/
+[Markdown-sane-lists]: https://python-markdown.github.io/extensions/sane_lists/

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Leave a pull request if you want your snippet repository to be listed.
 Currently, doctest is used for the `functions` module. To run the tests execute the following command:
 
 ```
-python3 src/functions.py
+python3 -m src.functions
 ``` 
 
 [Python-Markdown]: https://python-markdown.github.io/

--- a/main.py
+++ b/main.py
@@ -1,3 +1,9 @@
+import logging
+
+import gi
+gi.require_version('Notify', '0.7')
+from gi.repository import Notify, GdkPixbuf
+
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
@@ -13,6 +19,10 @@ from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
 
 from src.functions import get_snippets, copy_to_clipboard_xsel, copy_to_clipboard_wl
 from src.items import no_input_item, show_suggestion_items, show_var_input
+from src.html_to_text import html_to_text
+
+
+logger = logging.getLogger(__name__)
 
 
 class SnippetsExtension(Extension):
@@ -23,6 +33,8 @@ class SnippetsExtension(Extension):
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
         self.subscribe(ItemEnterEvent, ItemEnterEventLister())
         self.subscribe(SystemExitEvent, SystemExitEventListener())
+
+        Notify.init("ulauncher-snippets")
 
     def reset(self):
         self.snippet = None
@@ -51,24 +63,52 @@ class ItemEnterEventLister(EventListener):
                                next_variable, next_variable.get("default", ""))
             )])
 
-        copy_mode = extension.preferences["snippets_copy_mode"]
         try:
+            copy_mode = extension.preferences["snippets_copy_mode"]
             (mimetype, snippet) = extension.snippet.render(copy_mode=copy_mode)
+
+            action = None
+            if copy_mode == "xsel":
+                copy_to_clipboard_xsel(snippet, mimetype)
+                action = HideWindowAction()
+            elif copy_mode == "wl":
+                copy_to_clipboard_wl(snippet, mimetype)
+                action = HideWindowAction()
+            else:
+                action = CopyToClipboardAction(snippet)
+
+            self._notify(extension, snippet, mimetype)
+            return action
         except Exception as e:
+            logger.exception(e)
             return RenderResultListAction([
                 ExtensionResultItem(name=str(e), on_enter=DoNothingAction())
             ])
         finally:
             extension.reset()
 
-        if copy_mode == "xsel":
-            copy_to_clipboard_xsel(snippet, mimetype)
-            return HideWindowAction()
-        elif copy_mode == "wl":
-            copy_to_clipboard_wl(snippet, mimetype)
-            return HideWindowAction()
-        else:
-            return CopyToClipboardAction(snippet)
+    def _notify(self, extension, snippet, mimetype):
+        notification_behavior = extension.preferences["notification_behavior"]
+        if notification_behavior == "disabled":
+            return
+
+        notification = Notify.Notification.new("Snippet copied to clipboard")
+        notification.set_urgency(0) # lowest priority
+
+        try:
+            image = GdkPixbuf.Pixbuf.new_from_file(extension.snippet.icon)
+            notification.set_image_from_pixbuf(image)
+        except:
+            logger.exception("Failed to set notification icon")
+
+        if notification_behavior == "no_content":
+            return notification.show()
+
+        if notification_behavior == "with_content":
+            body = html_to_text(snippet) if mimetype == "text/html" else snippet
+            notification.update("Snippet copied to clipboard", body)
+
+        return notification.show()
 
 
 class KeywordQueryEventListener(EventListener):

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class ItemEnterEventLister(EventListener):
 
         copy_mode = extension.preferences["snippets_copy_mode"]
         try:
-            snippet = extension.snippet.render(copy_mode=copy_mode)
+            (mimetype, snippet) = extension.snippet.render(copy_mode=copy_mode)
         except Exception as e:
             return RenderResultListAction([
                 ExtensionResultItem(name=str(e), on_enter=DoNothingAction())
@@ -62,10 +62,10 @@ class ItemEnterEventLister(EventListener):
             extension.reset()
 
         if copy_mode == "xsel":
-            copy_to_clipboard_xsel(snippet)
+            copy_to_clipboard_xsel(snippet, mimetype)
             return HideWindowAction()
         elif copy_mode == "wl":
-            copy_to_clipboard_wl(snippet)
+            copy_to_clipboard_wl(snippet, mimetype)
             return HideWindowAction()
         else:
             return CopyToClipboardAction(snippet)

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,26 @@
           "text": "Wayland Clipboard Mode"
         }
       ]
+    },
+    {
+      "id": "notification_behavior",
+      "type": "select",
+      "name": "Desktop notifications",
+      "default_value": "disabled",
+      "options": [
+        {
+          "value": "disabled",
+          "text": "Don't send notifications"
+        },
+        {
+          "value": "no_content",
+          "text": "Notify without snippet content"
+        },
+        {
+          "value": "with_content",
+          "text": "Notify with snippet content"
+        }
+      ]
     }
   ]
 }

--- a/src/functions.py
+++ b/src/functions.py
@@ -86,7 +86,11 @@ class Snippet:
         if icon:
             self.icon = os.path.join(root_path, icon)
         else:
-            self.icon = "images/icon.png"
+            # Icon is allowed to be relative for ulauncher itself, but breaks with
+            # GdkPixbuf.Pixbuf.new_from_file() used to construct notifications.
+            # Making the path absolute avoids this problem.
+            script_path = os.path.dirname(os.path.abspath(__file__))
+            self.icon =  os.path.join(script_path, "..", "images/icon.png")
 
         self.globals_path = os.path.join(root_path, "globals.py")
         self.filters_path = os.path.join(root_path, "filters.py")

--- a/src/functions.py
+++ b/src/functions.py
@@ -13,15 +13,16 @@ import glob
 import dateparser
 import logging
 import frontmatter
+import subprocess
 from jinja2 import Template, environment, Environment
 from pathlib import Path
 from urllib.parse import unquote
 from ulauncher.utils.fuzzy_search import get_score
-from typing import List, Dict, Callable
-from subprocess import Popen, PIPE
+from typing import List, Dict, Callable, NewType
 
 from .filters import camelcase, pascalcase, kebabcase, snakecase
 
+MimeType = NewType('MimeType', str)
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +37,24 @@ class Snippet:
     """
     >>> s = Snippet('test-snippets/date.j2', 'test-snippets')
     >>> s.render()
-    '[[2020-12-09]] <== <button class="date_button_today">Today</button> ==> [[2020-12-11]]'
+    ('text/plain', '[[2020-12-09]] <== <button class="date_button_today">Today</button> ==> [[2020-12-11]]')
 
     >>> s = Snippet('test-snippets/frontmatter.j2', 'test-snippets')
     >>> s.render()
-    'Here is the content\\n\\n2020-12-10\\n\\nHi'
+    ('text/plain', 'Here is the content\\n\\n2020-12-10\\n\\nHi')
+
+    >>> s = Snippet('test-snippets/markdown.j2', 'test-snippets')
+    >>> s.render()
+    ('text/html', '<p>A snippet with <a href="https://daringfireball.net/projects/markdown/">Markdown</a> in it.</p>')
+
+    >>> s = Snippet('test-snippets/markdown-extensions.j2', 'test-snippets')
+    >>> s.render()
+    ('text/html', '<p>A snippet with <a class="wikilink" href="/Markdown/">Markdown</a> in it.</p>')
 
     >>> s = Snippet('test-snippets/react/component.j2', 'test-snippets')
     >>> s.variables["name"]["value"] = "My Component"
     >>> s.render()
-    'import React from "react"\\n\\nconst MyComponent = () => ();\\n\\nexport default MyComponent'
+    ('text/plain', 'import React from "react"\\n\\nconst MyComponent = () => ();\\n\\nexport default MyComponent')
 
     >>> s = Snippet('test-snippets/frontmatter.j2', 'test-snippets')
     >>> s.next_variable()
@@ -63,12 +72,11 @@ class Snippet:
 
     >>> s = Snippet('test-snippets/globals.j2', 'test-snippets')
     >>> s.render()
-    '€\\nMike Barkmin'
+    ('text/plain', '€\\nMike Barkmin')
 
     >>> s = Snippet('test-snippets/filters.j2', 'test-snippets')
     >>> s.render()
-    '*****'
-
+    ('text/plain', '*****')
     """
 
     def __init__(self, path: str, root_path: str = ""):
@@ -87,8 +95,10 @@ class Snippet:
         self.name = snippet.get("name", file_name[:-3])
         self.path = path
         self.description = snippet.get("description", snippet.content[:40])
+        self.is_markdown = snippet.get("markdown", False)
+        self.markdown_extensions = snippet.get("markdown_extensions", ["extra", "sane_lists"])
 
-    def render(self, args=[], copy_mode="gtk") -> str:
+    def render(self, args=[], copy_mode="gtk") -> (MimeType, str):
         snippet = frontmatter.load(self.path)
 
         filters = {}
@@ -112,7 +122,7 @@ class Snippet:
         elif copy_mode == "wl":
             clipboard_func = output_from_clipboard_wl
 
-        return template.render(
+        rendered_snippet = template.render(
             date=date,
             clipboard=clipboard_func,
             random_int=random_int,
@@ -121,6 +131,22 @@ class Snippet:
             vars=self.get_variable,
             **globals
         )
+        if self.is_markdown:
+            try:
+                # By importing this conditionally here we can keep this an
+                # optional dependency, only needed for people who want to use
+                # Markdown-rendered snippets.
+                import markdown
+            except ImportError as e:
+                raise Exception("Missing python-markdown package") from e
+            rendered_snippet = markdown.markdown(
+                rendered_snippet,
+                extensions=self.markdown_extensions,
+                output_format="html5"
+            )
+            return ("text/html", rendered_snippet)
+        else:
+            return ("text/plain", rendered_snippet)
 
     def next_variable(self):
         for id, variable in self.variables.items():
@@ -208,17 +234,18 @@ def random_item(list: List[str]) -> str:
     return random.choice(list)
 
 
-def copy_to_clipboard_xsel(text: str):
-    p = Popen(['xsel', '-bi'], stdin=PIPE)
-    p.communicate(input=text.encode("utf-8"))
+def copy_to_clipboard_xsel(text: str, mimetype: MimeType):
+    try:
+        # xsel does not support setting a mimetype, so try to use xclip when available but fall back to xsel.
+        subprocess.run(['xclip', '-target', mimetype, '-selection', 'clipboard'], input=text, encoding='utf-8', check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        subprocess.run(['xsel', '-bi'], input=text, encoding='utf-8', check=True)
 
-def copy_to_clipboard_wl(text: str):
-    p = Popen(['wl-copy'], stdin=PIPE)
-    p.communicate(input=text.encode("utf-8"))
-
+def copy_to_clipboard_wl(text: str, mimetype: MimeType):
+    subprocess.run(['wl-copy', '--type', mimetype], input=text, encoding='utf-8', check=True)
 
 def output_from_clipboard_xsel() -> str:
-    p = Popen(['xsel', '-bo'], stdout=PIPE, universal_newlines=True)
+    p = subprocess.Popen(['xsel', '-bo'], stdout=PIPE, universal_newlines=True)
     out, err = p.communicate()
 
     if err:
@@ -226,7 +253,7 @@ def output_from_clipboard_xsel() -> str:
     return convert_clipboard(out)
 
 def output_from_clipboard_wl() -> str:
-    p = Popen(['wl-paste'], stdout=PIPE, universal_newlines=True)
+    p = subprocess.Popen(['wl-paste'], stdout=PIPE, universal_newlines=True)
     out, err = p.communicate()
 
     if err:

--- a/src/html_to_text.py
+++ b/src/html_to_text.py
@@ -1,0 +1,49 @@
+from html.parser import HTMLParser
+from html.entities import name2codepoint
+
+
+class HTMLToText(HTMLParser):
+    """HTMLToText is a very rudimentary and naive HTML to plaintext parser"""
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self._buf = []
+
+    def text(self):
+        return "".join(self._buf)
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'br':
+            self._buf.append('\n')
+
+    def handle_startendtag(self, tag, attrs):
+        if tag == 'br':
+            self._buf.append('\n')
+
+    def handle_endtag(self, tag):
+        if tag == 'p':
+            self._buf.append('\n')
+
+    def handle_data(self, data):
+        self._buf.append(data)
+
+    def handle_entityref(self, name):
+        if name in name2codepoint:
+            c = chr(name2codepoint[name])
+            self._buf.append(c)
+
+    def handle_charref(self, name):
+        n = int(name[1:], 16) if name.startswith('x') else int(name)
+        self._buf.append(chr(n))
+
+
+def html_to_text(html: str) -> str:
+    """
+    Convert the given HTML to plaintext.
+
+    This is a very rudimentary parser, but it relies only on the Python stdlib.
+    It should be more than adequate for the HTML that is output by Markdown rendering.
+    """
+    parser = HTMLToText()
+    parser.feed(html)
+    parser.close()
+    return parser.text()

--- a/test-snippets/markdown-extensions.j2
+++ b/test-snippets/markdown-extensions.j2
@@ -1,0 +1,9 @@
+---
+name: "Second Markdown Snippet"
+description: "A snippet with some markdown in it, that sets custom extensions"
+markdown: true
+markdown_extensions:
+- wikilinks
+---
+
+A snippet with [[Markdown]] in it.

--- a/test-snippets/markdown.j2
+++ b/test-snippets/markdown.j2
@@ -1,0 +1,7 @@
+---
+name: "Markdown Snippet"
+description: "A snippet with some markdown in it"
+markdown: true
+---
+
+A snippet with [Markdown](https://daringfireball.net/projects/markdown/) in it.


### PR DESCRIPTION
## Description

This adds support for:

- Snippets containing Markdown source which can be rendered to HTML (d80e845b16ed19b13ed885bcbb8cb6f4857f7aab)
- Optional desktop notifications after copying a snippet to clipboard (f0d2e0cbb2f7008710f2fc2660a08aa2bce98cbd)

Because the desktop notifications work touched the same functions as the Markdown work did, I combined these into a single PR where one builds on top of the other.

I've tested this to work on both i3/X11 as well as sway/wayland. It should work on other DEs/WMs as well, though I have no tested how the notification will display on other notification daemons (but I expect no surprises there).

### Todo

- [x] Test on X11
- [x] Add documentation to README.
- [x] Update tests

[Markdown Extensions]: https://python-markdown.github.io/extensions/