### PR TITLE
Don't hang when variable defaults are not a string

### DIFF
--- a/src/items.py
+++ b/src/items.py
@@ -22,7 +22,7 @@ def no_input_item():
 
 
 def show_var_input(snippet, variable, value):
-    value = value.strip()
+    value = str(value).strip()
 
     if value == "-":
         variable["value"] = variable.get("default", "")


### PR DESCRIPTION
Given the following vars in a snippet:

```
vars:
  length:
    label: "Length"
    default: 16
```

The following exception will be thrown:

```
ulauncher-snippets | 2021-05-07 20:50:59,207 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event ItemEnterEvent
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3.9/site-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/main.py", line 51, in on_event
    show_var_input(extension.snippet,
  File "/home/zoni/Workspace/zoni/ulauncher-snippets/src/items.py", line 25, in show_var_input
    value = value.strip()
AttributeError: 'int' object has no attribute 'strip'
```

This does not happen when the vars are defined as:

```
vars:
  length:
    label: "Length"
    default: "16"
```

Forcing the value to a string avoids this exception. Calling `str()` on data that is already a string should effectively be a no-op, so this should not cause any regressions.