### PR TITLE
Limit number of suggestions

### DIFF
--- a/src/items.py
+++ b/src/items.py
@@ -59,5 +59,5 @@ def show_suggestion_items(suggestions: List[Snippet]):
                 "snippet": suggestion
             }, keep_app_open=True),
         )
-        for suggestion in suggestions
+        for suggestion in suggestions[:8]
     ]


### PR DESCRIPTION
Great extension!

If you have many snippets, the Ulauncher window will keep growing until it reaches the end of the screen., which looks ugly.

On my extensions, I usually limit the visible results to 8, which I think is a good value to keep the Ulauncher window in a decent size. You can still filter down to reduce the number of matched items.